### PR TITLE
Change keyboard shortcuts & add window placement algorithm

### DIFF
--- a/source/tvterm/app.cc
+++ b/source/tvterm/app.cc
@@ -182,10 +182,125 @@ static void onTermError(const char *reason)
     messageBox(mfError | mfOKButton, "Cannot create terminal: %s.", reason);
 };
 
+void setCenter(TRect& rect, const TPoint pt)
+{
+    int w = (rect.b.x - rect.a.x);
+    int h = (rect.b.y - rect.a.y);
+
+    rect.a.x = pt.x - w/2;
+    rect.a.y = pt.y - h/2;
+    rect.b.x = pt.x - w/2 + w;  // Keeps odd sizes
+    rect.b.y = pt.y - h/2 + h;
+}
+
+TPoint getCenter(const TRect& rect)
+{
+    TPoint c = {
+        (rect.a.x + rect.b.x) / 2,
+        (rect.a.y + rect.b.y) / 2
+    };
+    return c;
+}
+
+TRect TVTermApp::newWindowCoords()
+{
+    size_t count = getOpenTermCount();
+    TRect dtop_bounds = deskTop->getExtent();
+
+    if (count == 0)
+    {
+        // If there aren't any windows, fill the whole desktop
+        return deskTop->getExtent();
+    }
+    else if (count == 1)
+    {
+        // If there is a single window that is maximized, split the desktop equally.
+        TView *existing = deskTop->first();
+
+        if (existing->getBounds() == dtop_bounds)
+        {
+            TRect left = dtop_bounds;
+            left.b.x /= 2;      // Make it cover only half the screen
+            existing->changeBounds(left);
+            
+            TRect right = dtop_bounds;
+            right.a.x = left.b.x;
+            return right;
+        }
+        // Else maximized
+        return dtop_bounds;
+    }
+    else if (count == 2)
+    {
+        // If there are 2 tiled windows, start making floating ones
+        if (deskTop->first()->getBounds().Union(deskTop->first()->nextView()->getBounds()) == dtop_bounds)
+        {
+            TRect new_bounds = dtop_bounds;
+            // Make the window half the screen size
+            new_bounds.b.x /= 2;
+            new_bounds.b.y = (dtop_bounds.b.y * 2) / 3;
+            setCenter(new_bounds, getCenter(dtop_bounds));
+            return new_bounds;
+        }
+
+        // Otherwise follow standard Many Window behavior
+    }
+
+    // Many windows. The goal is to stagger the windows in a way that they don't overlap each other fully.
+
+    // Same size as the most recently created window
+    TView *last_window = deskTop->first();  // Apparently TVision prepends new windows
+    TRect new_bounds = last_window->getBounds();
+
+    // Find the center of 'gravity' of existing windows.
+    signed int avg_x = 0;
+    signed int avg_y = 0;   // Average distance of center of the window from the center of the desktop
+    int n = 0;
+
+    TPoint dtop_center = getCenter(dtop_bounds);
+
+    for (TView *cur = deskTop->first(); cur != NULL; cur = cur->nextView())
+    {
+        TPoint cur_center = getCenter(cur->getBounds());
+
+        if (cur_center.x != dtop_center.x && cur_center.y != dtop_center.y)     // Only count windows that aren't centred in any way.
+        {
+            avg_x += (cur_center.x - dtop_center.x);
+            avg_y += (cur_center.y - dtop_center.y);
+        }
+
+        // messageBox(0, "(%d,%d) => (%d,%d)", cur_center.x, cur_center.y, dtop_center.x, dtop_center.y);
+
+        n++;
+    }
+
+    avg_x /= n;
+    avg_y /= n;
+
+    // Place the new window opposite this average point with respect to the center.
+    setCenter(new_bounds, {
+        dtop_center.x + (-avg_x),
+        dtop_center.y + (-avg_y),
+    });
+
+    // If it is still fully overlapping another window (the window layout is probably symmetrical), move it by (1,1).
+    do {
+        bool unique = true;
+        for (TView *cur = deskTop->first(); cur != NULL; cur = cur->nextView())
+            if (new_bounds.a == cur->getBounds().a)
+                unique = false;
+        
+        if (!unique)
+            new_bounds.move(1, 1);
+        else
+            return new_bounds;
+    } while (1);
+}
+
 void TVTermApp::newTerm()
 {
     using namespace tvterm;
-    TRect r = deskTop->getExtent();
+    TRect r = newWindowCoords();
     auto *term = TerminalActivity::create( TerminalWindow::viewSize(r),
                                            VTermAdapter::create,
                                            VTermAdapter::childActions,

--- a/source/tvterm/app.cc
+++ b/source/tvterm/app.cc
@@ -74,11 +74,14 @@ TMenuBar *TVTermApp::initMenuBar(TRect r)
             *new TMenuItem( "~M~ove/Resize",cmResize, kbAltM, hcNoContext, "Alt-M" ) +
             *new TMenuItem( "~Z~oom", cmZoom, kbAltZ, hcNoContext, "Alt-Z" ) +
             *new TMenuItem( "~T~ile (Columns First)", cmTileCols, kbAltT, hcNoContext, "Alt-T" ) +
-            *new TMenuItem( "Tile (~R~ows First)", cmTileRows, kbNoKey ) +
             *new TMenuItem( "C~a~scade", cmCascade, kbNoKey ) +
+            newLine() +
+            *new TMenuItem( "Snap ~L~eft", cmSnapL, kbAltL, hcNoContext, "Alt-L" ) +
+            *new TMenuItem( "Snap ~R~ight", cmSnapR, kbAltR, hcNoContext, "Alt-R" ) +
+            newLine() +
             *new TMenuItem( "~N~ext", cmNext, kbAltEqual, hcNoContext, "Alt-+" ) +
             *new TMenuItem( "~P~revious", cmPrev, kbAltMinus, hcNoContext, "Alt--" ) +
-            *new TMenuItem( "~C~lose", cmClose, kbAltX, hcNoContext, "Alt-X" /*TODO: Also Alt-W (what ppl are used to)*/ )
+            *new TMenuItem( "~C~lose", cmClose, kbAltW, hcNoContext, "Alt-W" /*TODO: Also Alt-X*/ )
     );
 }
 
@@ -110,23 +113,40 @@ void TVTermApp::handleEvent(TEvent &event)
 {
     TApplication::handleEvent(event);
     bool handled = true;
-    switch (event.what)
+    if (event.what & evCommand)
     {
-        case evCommand:
-            switch (event.message.command)
-            {
-                case cmNewTerm: newTerm(); break;
-                case cmChangeDir: changeDir(); break;
-                case cmTileCols: getDeskTop()->tileVertical(getTileRect()); break;
-                case cmTileRows: getDeskTop()->tileHorizontal(getTileRect()); break;
-                default:
-                    handled = false;
-                    break;
-            }
-            break;
-        default:
-            handled = false;
-            break;
+        switch (event.message.command)
+        {
+            case cmNewTerm: newTerm(); break;
+            case cmChangeDir: changeDir(); break;
+            case cmTileCols: getDeskTop()->tileVertical(getTileRect()); break;
+            case cmSnapL:
+                if (deskTop->current)
+                {
+                    TRect bounds = deskTop->getExtent();
+                    bounds.b.x /= 2;
+                    deskTop->current->changeBounds(bounds);
+                }
+                break;
+            case cmSnapR:
+                if (deskTop->current)
+                {
+                    TRect bounds = deskTop->getExtent();
+                    bounds.a.x = bounds.b.x / 2;
+                    deskTop->current->changeBounds(bounds);
+                }
+                break;
+            default:
+                handled = false;
+                break;
+        }
+    }
+    else if (event.what & evKeyboard)
+    {
+        handled = false;
+    }
+    else {
+        handled = false;
     }
     if (handled)
         clearEvent(event);

--- a/source/tvterm/app.cc
+++ b/source/tvterm/app.cc
@@ -59,21 +59,27 @@ TMenuBar *TVTermApp::initMenuBar(TRect r)
     r.b.y = r.a.y+1;
     return new TMenuBar( r,
         *new TSubMenu( "~F~ile", kbAltF, hcNoContext ) +
-            *new TMenuItem( "~N~ew", cmNewTerm, kbCtrlN, hcNoContext, "Ctrl-N" ) +
+            // The rational for using Alt+_ shortctus for window management is that
+            // most TUI apps are not sofisticated enough to need the Alt key
+            // for shortcuts (usually only F-keys and sometimes Ctrl are used).
+            // This frees us to use Alt + <intuitive letter> with only a minimal chance
+            // of it clashing with an app.
+
+            *new TMenuItem( "~N~ew Window", cmNewTerm, kbAltN, hcNoContext, "Alt-N" ) +
             newLine() +
             *new TMenuItem( "~C~hange dir...", cmChangeDir, kbNoKey ) +
             *new TMenuItem( "S~u~spend", cmDosShell, kbNoKey, hcNoContext ) +
-            *new TMenuItem( "E~x~it", cmQuit, kbAltX, hcNoContext, "Alt-X" ) +
+            *new TMenuItem( "E~x~it", cmQuit, kbAltQ, hcNoContext, "Alt-Q" ) +
         *new TSubMenu( "~W~indows", kbAltW ) +
-            *new TMenuItem( "~S~ize/move",cmResize, kbCtrlF5, hcNoContext, "Ctrl-F5" ) +
-            *new TMenuItem( "~Z~oom", cmZoom, kbF5, hcNoContext, "F5" ) +
-            *new TMenuItem( "~T~ile (Columns First)", cmTileCols, kbNoKey ) +
+            *new TMenuItem( "~M~ove/Resize",cmResize, kbAltM, hcNoContext, "Alt-M" ) +
+            *new TMenuItem( "~Z~oom", cmZoom, kbAltZ, hcNoContext, "Alt-Z" ) +
+            *new TMenuItem( "~T~ile (Columns First)", cmTileCols, kbAltT, hcNoContext, "Alt-T" ) +
             *new TMenuItem( "Tile (~R~ows First)", cmTileRows, kbNoKey ) +
             *new TMenuItem( "C~a~scade", cmCascade, kbNoKey ) +
-            *new TMenuItem( "~N~ext", cmNext, kbF6, hcNoContext, "F6" ) +
-            *new TMenuItem( "~P~revious", cmPrev, kbShiftF6, hcNoContext, "Shift-F6" ) +
-            *new TMenuItem( "~C~lose", cmClose, kbAltF3, hcNoContext, "Alt+F3" )
-            );
+            *new TMenuItem( "~N~ext", cmNext, kbAltEqual, hcNoContext, "Alt-+" ) +
+            *new TMenuItem( "~P~revious", cmPrev, kbAltMinus, hcNoContext, "Alt--" ) +
+            *new TMenuItem( "~C~lose", cmClose, kbAltX, hcNoContext, "Alt-X" /*TODO: Also Alt-W (what ppl are used to)*/ )
+    );
 }
 
 TStatusLine *TVTermApp::initStatusLine( TRect r )
@@ -88,10 +94,9 @@ TStatusLine *TVTermApp::initStatusLine( TRect r )
         *new TStatusDef( hcInputGrabbed, hcInputGrabbed ) +
             *new TStatusItem( "~Alt-PgDn~ Release Input", kbAltPgDn, cmReleaseInput ) +
         *new TStatusDef( 0, 0xFFFF ) +
-            *new TStatusItem( "~Ctrl-N~ New", kbNoKey, cmNewTerm ) +
-            *new TStatusItem( "~F6~ Next", kbNoKey, cmNext ) +
-            *new TStatusItem( "~Alt-PgUp~ Grab Input", kbAltPgUp, cmGrabInput ) +
-            *new TStatusItem( "~F12~ Menu" , kbF12, cmMenu )
+            *new TStatusItem( "~Alt-Q~ Quit", kbNoKey, cmNewTerm ) +
+            *new TStatusItem( "~F12~ Menu" , kbF12, cmMenu ) +
+            *new TStatusItem( "~Alt-PgUp~ Grab Input", kbAltPgUp, cmGrabInput )
             );
 }
 

--- a/source/tvterm/app.h
+++ b/source/tvterm/app.h
@@ -27,13 +27,14 @@ struct TVTermApp : public TApplication
     Boolean valid(ushort command) override;
     void idle() override;
 
+private:
     size_t getOpenTermCount();
+    TRect newWindowCoords();
 
     // Command handlers
-
+public:
     void newTerm();
     void changeDir();
-
 };
 
 inline TVTermDesk* TVTermApp::getDeskTop()

--- a/source/tvterm/cmds.h
+++ b/source/tvterm/cmds.h
@@ -8,6 +8,8 @@ enum : ushort {
     cmReleaseInput,
     cmTileCols,
     cmTileRows,
+    cmSnapL,
+    cmSnapR,
     // Commands that cannot be deactivated.
     cmNewTerm           = 1000,
     cmIdle,


### PR DESCRIPTION
Hi, I've made a couple of changes:
* Added an algorithm that places new windows so that they dont fully overlap
* Changed all keyboard shortcuts from a combinaiton of `Fxx` and `Ctrl-x` to `Alt-x`. Having all tvterm shortcuts be Alt-<first letter of the action word> makes them easier to remember. What's more, `Alt-` shortcuts are unlikely to clash with TUI apps running inside the windows, as TUI apps hardly ever use the Alt key.