### PR TITLE
Add text selection with copy-to-clipboard

### DIFF
--- a/include/tvterm/consts.h
+++ b/include/tvterm/consts.h
@@ -8,15 +8,16 @@ struct TVTermConstants
 {
     ushort cmCheckTerminalUpdates;
     ushort cmTerminalUpdated;
-    // Focused commands
+    // Focused commands (enabled/disabled on window focus)
     ushort cmGrabInput;
     ushort cmReleaseInput;
+    ushort cmCopySelection;
     // Help contexts
     ushort hcInputGrabbed;
 
     TSpan<const ushort> focusedCmds() const
     {
-        return {&cmGrabInput, size_t(&cmReleaseInput + 1 - &cmGrabInput)};
+        return {&cmGrabInput, size_t(&cmCopySelection + 1 - &cmGrabInput)};
     }
 };
 

--- a/include/tvterm/termemu.h
+++ b/include/tvterm/termemu.h
@@ -87,6 +87,8 @@ struct TerminalState
 
     bool titleChanged {false};
     GrowArray title;
+
+    bool mouseEnabled {false};
 };
 
 enum class TerminalEventType

--- a/include/tvterm/termview.h
+++ b/include/tvterm/termview.h
@@ -20,9 +20,25 @@ class TerminalView : public TView
     const TVTermConstants &consts;
     bool ownerBufferChanged {false};
 
+    // Selection state (main thread only, no sync needed)
+    struct Selection
+    {
+        TPoint anchor {0, 0};
+        TPoint current {0, 0};
+        bool active {false};    // drag in progress
+        bool valid {false};     // completed selection exists
+    };
+
+    Selection selection;
+    bool cachedMouseEnabled {false};
+
     void handleMouse(ushort what, MouseEventType mouse) noexcept;
+    void handleSelectionMouse(ushort what, TPoint localPos) noexcept;
     void updateCursor(TerminalState &state) noexcept;
     void updateDisplay(TerminalSurface &surface) noexcept;
+    void applySelectionHighlight(TerminalSurface &surface) noexcept;
+    void normalizeSelection(TPoint &start, TPoint &end) const noexcept;
+    void clearSelection() noexcept;
     bool canReuseOwnerBuffer() noexcept;
 
 public:
@@ -39,6 +55,8 @@ public:
     void setState(ushort aState, bool enable) override;
     void handleEvent(TEvent &ev) override;
     void draw() override;
+
+    void copySelection() noexcept;
 };
 
 } // namespace tvterm

--- a/source/tvterm-core/pty.cc
+++ b/source/tvterm-core/pty.cc
@@ -8,10 +8,13 @@
 #include <unistd.h>
 #include <signal.h>
 #include <fcntl.h>
+#include <spawn.h>
 #include <sys/ioctl.h>
 #include <sys/wait.h>
 #include <termios.h>
 #include <errno.h>
+#include <string>
+#include <vector>
 
 #if __has_include(<pty.h>)
 #   include <pty.h>
@@ -21,11 +24,18 @@
 #   include <util.h>
 #endif
 
+extern char **environ;
+
 namespace tvterm
 {
 
 static struct termios createTermios() noexcept;
 static struct winsize createWinsize(TPoint size) noexcept;
+static bool spawnPtyClient( int masterFd, int slaveFd, pid_t &clientPid,
+                           TSpan<const EnvironmentVar> customEnvironment ) noexcept;
+static std::vector<std::string> buildEnvironment(
+    TSpan<const EnvironmentVar> customEnvironment ) noexcept;
+static const char *findEnvironmentValue(const std::vector<std::string> &env, const char *name) noexcept;
 
 bool createPty( PtyDescriptor &ptyDescriptor, TPoint size,
                 TSpan<const EnvironmentVar> customEnvironment,
@@ -33,44 +43,150 @@ bool createPty( PtyDescriptor &ptyDescriptor, TPoint size,
 {
     auto termios = createTermios();
     auto winsize = createWinsize(size);
-    int masterFd;
-    pid_t clientPid = forkpty(&masterFd, nullptr, &termios, &winsize);
-    if (clientPid == 0)
+    int masterFd = -1, slaveFd = -1;
+    if (openpty(&masterFd, &slaveFd, nullptr, &termios, &winsize) == -1)
     {
-        // Use the default ISIG signal handlers.
-        signal(SIGINT,  SIG_DFL);
-        signal(SIGQUIT, SIG_DFL);
-        signal(SIGSTOP, SIG_DFL);
-        signal(SIGCONT, SIG_DFL);
-
-        for (const auto &envVar : customEnvironment)
-            setenv(envVar.name, envVar.value, 1);
-
-        char *shell = getenv("SHELL");
-        char *args[] = {shell, nullptr};
-        execvp(shell, args);
-
-        setbuf(stderr, nullptr); // Ensure 'stderr' is unbuffered.
-        fprintf(
-            stderr,
-            "\x1B[1;31m" // Color attributes: bold and red.
-            "Error: Failed to execute the program specified by the environment variable SHELL ('%s'): %s"
-            "\x1B[0m", // Reset color attributes.
-            (shell ? shell : ""),
-            strerror(errno)
-        );
-
-        // Exit the subprocess without cleaning up resources.
-        _Exit(EXIT_FAILURE);
-    }
-    else if (clientPid == -1)
-    {
-        char *str = formatStr("forkpty failed: %s", strerror(errno));
+        char *str = formatStr("openpty failed: %s", strerror(errno));
         onError(str);
         delete[] str;
         return false;
     }
+
+    pid_t clientPid = -1;
+    if (!spawnPtyClient(masterFd, slaveFd, clientPid, customEnvironment))
+    {
+        int err = errno;
+        close(masterFd);
+        close(slaveFd);
+        char *str = formatStr("pty child spawn failed: %s", strerror(err));
+        onError(str);
+        delete[] str;
+        return false;
+    }
+
+    close(slaveFd);
     ptyDescriptor = {masterFd, clientPid};
+    return true;
+}
+
+static std::vector<std::string> buildEnvironment(
+    TSpan<const EnvironmentVar> customEnvironment ) noexcept
+{
+    std::vector<std::string> env;
+    std::vector<bool> customUsed(customEnvironment.size(), false);
+
+    for (char **p = environ; p && *p; ++p)
+    {
+        const char *entry = *p;
+        const char *eq = strchr(entry, '=');
+        if (!eq)
+            continue;
+
+        size_t nameLen = size_t(eq - entry);
+        bool replaced = false;
+        for (size_t i = 0; i < customEnvironment.size(); ++i)
+        {
+            const auto &envVar = customEnvironment[i];
+            if (strlen(envVar.name) == nameLen &&
+                strncmp(entry, envVar.name, nameLen) == 0)
+            {
+                env.emplace_back(std::string(envVar.name) + "=" + envVar.value);
+                customUsed[i] = true;
+                replaced = true;
+                break;
+            }
+        }
+        if (!replaced)
+            env.emplace_back(entry);
+    }
+
+    for (size_t i = 0; i < customEnvironment.size(); ++i)
+        if (!customUsed[i])
+            env.emplace_back(std::string(customEnvironment[i].name) + "=" +
+                             customEnvironment[i].value);
+
+    return env;
+}
+
+static const char *findEnvironmentValue(const std::vector<std::string> &env,
+                                        const char *name) noexcept
+{
+    size_t nameLen = strlen(name);
+    for (const auto &entry : env)
+        if (entry.size() > nameLen &&
+            entry.compare(0, nameLen, name) == 0 &&
+            entry[nameLen] == '=')
+            return entry.c_str() + nameLen + 1;
+    return nullptr;
+}
+
+static void setDefaultSignalHandler(int signum) noexcept
+{
+    struct sigaction sa = {};
+    sa.sa_handler = SIG_DFL;
+    sigemptyset(&sa.sa_mask);
+    sigaction(signum, &sa, nullptr);
+}
+
+static bool spawnPtyClient( int masterFd, int slaveFd, pid_t &clientPid,
+                           TSpan<const EnvironmentVar> customEnvironment ) noexcept
+{
+    auto envStorage = buildEnvironment(customEnvironment);
+    const char *shell = findEnvironmentValue(envStorage, "SHELL");
+    if (!shell || !*shell)
+        shell = "/bin/sh";
+
+    std::vector<char *> envp;
+    envp.reserve(envStorage.size() + 1);
+    for (auto &entry : envStorage)
+        envp.push_back(&entry[0]);
+    envp.push_back(nullptr);
+
+    char *args[] = {const_cast<char *>(shell), nullptr};
+
+    pid_t pid = vfork();
+    if (pid == -1)
+        return false;
+    if (pid == 0)
+    {
+        // Child path: avoid non-essential libc work before exec.
+        if (setsid() == -1)
+            goto exec_fail;
+
+#ifdef TIOCSCTTY
+        if (ioctl(slaveFd, TIOCSCTTY, 0) == -1)
+            goto exec_fail;
+#endif
+
+        setDefaultSignalHandler(SIGINT);
+        setDefaultSignalHandler(SIGQUIT);
+        setDefaultSignalHandler(SIGSTOP);
+        setDefaultSignalHandler(SIGCONT);
+
+        if (dup2(slaveFd, STDIN_FILENO) == -1 ||
+            dup2(slaveFd, STDOUT_FILENO) == -1 ||
+            dup2(slaveFd, STDERR_FILENO) == -1)
+            goto exec_fail;
+
+        close(masterFd);
+        if (slaveFd > STDERR_FILENO)
+            close(slaveFd);
+
+        execve(shell, args, envp.data());
+
+exec_fail:
+        dprintf(
+            STDERR_FILENO,
+            "\x1B[1;31m"
+            "Error: Failed to execute the program specified by the environment variable SHELL ('%s'): %s"
+            "\x1B[0m",
+            (shell ? shell : ""),
+            strerror(errno)
+        );
+        _Exit(EXIT_FAILURE);
+    }
+
+    clientPid = pid;
     return true;
 }
 

--- a/source/tvterm-core/termview.cc
+++ b/source/tvterm-core/termview.cc
@@ -6,6 +6,8 @@
 #define Uses_TEvent
 #include <tvision/tv.h>
 
+#include <stdio.h>
+
 namespace tvterm
 {
 
@@ -29,6 +31,7 @@ TerminalView::~TerminalView()
 void TerminalView::changeBounds(const TRect& bounds)
 {
     setBounds(bounds);
+    clearSelection();
     ownerBufferChanged = true;
     drawView();
 
@@ -60,6 +63,14 @@ void TerminalView::handleEvent(TEvent &ev)
 
     switch (ev.what)
     {
+        case evCommand:
+            if (ev.message.command == consts.cmCopySelection)
+            {
+                copySelection();
+                clearEvent(ev);
+            }
+            break;
+
         case evBroadcast:
             if ( ev.message.command == consts.cmCheckTerminalUpdates &&
                  termCtrl.stateHasBeenUpdated() )
@@ -68,6 +79,14 @@ void TerminalView::handleEvent(TEvent &ev)
 
         case evKeyDown:
         {
+            // Clear selection on any keypress
+            if (selection.active || selection.valid)
+            {
+                clearSelection();
+                ownerBufferChanged = true;
+                drawView();
+            }
+
             TerminalEvent termEvent;
             termEvent.type = TerminalEventType::KeyDown;
             termEvent.keyDown = ev.keyDown;
@@ -78,15 +97,41 @@ void TerminalView::handleEvent(TEvent &ev)
         }
 
         case evMouseDown:
-            do {
-                handleMouse(ev.what, ev.mouse);
-            } while (mouseEvent(ev, evMouse));
-            if (ev.what == evMouseUp)
-                handleMouse(ev.what, ev.mouse);
-            clearEvent(ev);
+            // Left button + !mouseEnabled → selection mode
+            if (!cachedMouseEnabled && (ev.mouse.buttons & mbLeftButton))
+            {
+                TPoint localPos = makeLocal(ev.mouse.where);
+                handleSelectionMouse(evMouseDown, localPos);
+                while (mouseEvent(ev, evMouse))
+                {
+                    localPos = makeLocal(ev.mouse.where);
+                    handleSelectionMouse(ev.what, localPos);
+                }
+                if (ev.what == evMouseUp)
+                {
+                    localPos = makeLocal(ev.mouse.where);
+                    handleSelectionMouse(evMouseUp, localPos);
+                }
+                clearEvent(ev);
+            }
+            else
+            {
+                // Forward to emulator (existing behavior)
+                do {
+                    handleMouse(ev.what, ev.mouse);
+                } while (mouseEvent(ev, evMouse));
+                if (ev.what == evMouseUp)
+                    handleMouse(ev.what, ev.mouse);
+                clearEvent(ev);
+            }
             break;
 
         case evMouseWheel:
+            // Always forward wheel to emulator
+            handleMouse(ev.what, ev.mouse);
+            clearEvent(ev);
+            break;
+
         case evMouseMove:
         case evMouseAuto:
         case evMouseUp:
@@ -106,9 +151,69 @@ void TerminalView::handleMouse(ushort what, MouseEventType mouse) noexcept
     termCtrl.sendEvent(termEvent);
 }
 
+void TerminalView::handleSelectionMouse(ushort what, TPoint localPos) noexcept
+{
+    // Clamp to view bounds
+    localPos.x = max(0, min(localPos.x, size.x - 1));
+    localPos.y = max(0, min(localPos.y, size.y - 1));
+
+    if (what & evMouseDown)
+    {
+        selection.anchor = localPos;
+        selection.current = localPos;
+        selection.active = true;
+        selection.valid = false;
+        ownerBufferChanged = true;
+        drawView();
+    }
+    else if (what & (evMouseMove | evMouseAuto))
+    {
+        if (selection.active && localPos != selection.current)
+        {
+            selection.current = localPos;
+            ownerBufferChanged = true;
+            drawView();
+        }
+    }
+    else if (what & evMouseUp)
+    {
+        if (selection.active)
+        {
+            selection.current = localPos;
+            selection.active = false;
+            selection.valid = true;
+            ownerBufferChanged = true;
+            drawView();
+        }
+    }
+}
+
+void TerminalView::normalizeSelection(TPoint &start, TPoint &end) const noexcept
+{
+    TPoint a = selection.anchor;
+    TPoint b = selection.current;
+    if (a.y < b.y || (a.y == b.y && a.x <= b.x))
+    {
+        start = a;
+        end = b;
+    }
+    else
+    {
+        start = b;
+        end = a;
+    }
+}
+
+void TerminalView::clearSelection() noexcept
+{
+    selection.active = false;
+    selection.valid = false;
+}
+
 void TerminalView::draw()
 {
     termCtrl.lockState([&] (auto &state) {
+        cachedMouseEnabled = state.mouseEnabled;
         updateCursor(state);
         updateDisplay(state.surface);
 
@@ -149,11 +254,133 @@ void TerminalView::updateDisplay(TerminalSurface &surface) noexcept
         for (int y = r.a.y; y < r.b.y; ++y)
         {
             auto c = rangeToCopy(y, r, surface, reuseBuffer);
-            writeLine(c.begin, y, c.end - c.begin, 1, &surface.at(y, c.begin));
+            if (c.begin < c.end)
+                writeLine(c.begin, y, c.end - c.begin, 1, &surface.at(y, c.begin));
         }
         surface.clearDamage();
-        // We don't need to draw the area that is not filled by the surface.
-        // It will be blank.
+    }
+
+    // Apply selection highlight
+    if (selection.active || selection.valid)
+        applySelectionHighlight(surface);
+}
+
+void TerminalView::applySelectionHighlight(TerminalSurface &surface) noexcept
+{
+    TPoint start, end;
+    normalizeSelection(start, end);
+
+    // Clamp against surface and view bounds
+    int limitX = min(surface.size.x, size.x);
+    int limitY = min(surface.size.y, size.y);
+    if (limitX <= 0 || limitY <= 0)
+        return;
+    start.x = max(0, min(start.x, limitX - 1));
+    start.y = max(0, min(start.y, limitY - 1));
+    end.x = max(0, min(end.x, limitX - 1));
+    end.y = max(0, min(end.y, limitY - 1));
+
+    for (int y = start.y; y <= end.y; ++y)
+    {
+        int selBegin = (y == start.y) ? start.x : 0;
+        int selEnd = (y == end.y) ? end.x + 1 : limitX;
+        selBegin = max(selBegin, 0);
+        selEnd = min(selEnd, limitX);
+
+        if (selBegin >= selEnd)
+            continue;
+
+        // Adjust for wide char boundaries
+        if (selBegin > 0 && surface.at(y, selBegin)._ch.isWideCharTrail())
+            --selBegin;
+        if (selEnd < limitX && surface.at(y, selEnd - 1).isWide())
+            ++selEnd;
+        selEnd = min(selEnd, limitX);
+
+        int count = selEnd - selBegin;
+        if (count <= 0)
+            continue;
+
+        // Build modified cells with reversed attributes
+        TScreenCell buf[256];
+        TScreenCell *cells = (count <= 256) ? buf : new TScreenCell[count];
+
+        for (int i = 0; i < count; ++i)
+        {
+            cells[i] = surface.at(y, selBegin + i);
+            ::setAttr(cells[i], ::reverseAttribute(::getAttr(cells[i])));
+        }
+
+        writeLine(selBegin, y, count, 1, cells);
+
+        if (cells != buf)
+            delete[] cells;
+    }
+}
+
+void TerminalView::copySelection() noexcept
+{
+    if (!selection.valid)
+        return;
+
+    GrowArray text;
+    termCtrl.lockState([&] (auto &state) {
+        auto &surface = state.surface;
+        TPoint start, end;
+        normalizeSelection(start, end);
+
+        int limitX = surface.size.x;
+        int limitY = surface.size.y;
+        for (int y = start.y; y <= end.y && y < limitY; ++y)
+        {
+            int lineBegin = (y == start.y) ? start.x : 0;
+            int lineEnd = (y == end.y) ? end.x + 1 : limitX;
+            lineBegin = max(lineBegin, 0);
+            lineEnd = min(lineEnd, limitX);
+
+            for (int x = lineBegin; x < lineEnd; ++x)
+            {
+                auto &cell = surface.at(y, x);
+                if (cell._ch.isWideCharTrail())
+                    continue;
+
+                TStringView cellText = cell._ch.getText();
+                if (cellText.size() == 1 && cellText[0] == '\0')
+                {
+                    char sp = ' ';
+                    text.push(&sp, 1);
+                }
+                else
+                {
+                    text.push(cellText.data(), cellText.size());
+                }
+            }
+
+            if (y < end.y)
+            {
+                char nl = '\n';
+                text.push(&nl, 1);
+            }
+        }
+    });
+
+    if (text.size() > 0)
+    {
+#if !defined(_WIN32)
+        FILE *pipe = popen(
+            "pbcopy 2>/dev/null || "
+            "xclip -selection clipboard 2>/dev/null || "
+            "xsel --clipboard --input 2>/dev/null",
+            "w"
+        );
+        if (pipe)
+        {
+            fwrite(text.data(), 1, text.size(), pipe);
+            pclose(pipe);
+        }
+#else
+        // TODO: Windows clipboard via OpenClipboard/SetClipboardData
+#endif
     }
 }
 

--- a/source/tvterm-core/vtermemu.cc
+++ b/source/tvterm-core/vtermemu.cc
@@ -267,6 +267,13 @@ VTermEmulator::VTermEmulator(TPoint size, Writer &aClientDataWriter) noexcept :
     vtState = vterm_obtain_state(vt);
     vterm_state_reset(vtState, true);
 
+    // Force pure black background (default may be dark grey on some platforms)
+    VTermColor blackBg;
+    vterm_color_rgb(&blackBg, 0, 0, 0);
+    VTermColor whiteFg;
+    vterm_color_rgb(&whiteFg, 255, 255, 255);
+    vterm_state_set_default_colors(vtState, &whiteFg, &blackBg);
+
     vtScreen = vterm_obtain_screen(vt);
     vterm_screen_enable_altscreen(vtScreen, true);
     vterm_screen_set_callbacks(vtScreen, &callbacks, this);

--- a/source/tvterm-core/vtermemu.cc
+++ b/source/tvterm-core/vtermemu.cc
@@ -345,6 +345,7 @@ void VTermEmulator::updateState(TerminalState &state) noexcept
         state.titleChanged = true;
         state.title = std::move(localState.title);
     }
+    state.mouseEnabled = localState.mouseEnabled;
 }
 
 TPoint VTermEmulator::getSize() noexcept

--- a/source/tvterm/app.cc
+++ b/source/tvterm/app.cc
@@ -152,6 +152,7 @@ void TVTermApp::openMenu()
     TMenuItem &menuItems =
         *new TMenuItem("New Term", cmNewTerm, 'N', hcNoContext, "~N~") +
         *new TMenuItem("Close Term", cmClose, 'W', hcNoContext, "~W~") +
+        *new TMenuItem("~C~opy Selection", cmCopySelection, kbNoKey) +
         newLine() +
         *new TMenuItem("Next Term", cmNext, kbTab, hcNoContext, "~Tab~") +
         *new TMenuItem("Previous Term", cmPrev, kbShiftTab, hcNoContext, "~Shift-Tab~") +

--- a/source/tvterm/cmds.h
+++ b/source/tvterm/cmds.h
@@ -9,6 +9,7 @@ enum : ushort
     cmReleaseInput,
     cmTileCols,
     cmTileRows,
+    cmCopySelection,
     // Commands that cannot be deactivated.
     cmNewTerm = 1000,
     cmCheckTerminalUpdates,

--- a/source/tvterm/wnd.cc
+++ b/source/tvterm/wnd.cc
@@ -10,6 +10,7 @@ const tvterm::TVTermConstants TerminalWindow::appConsts =
     cmTerminalUpdated,
     cmGrabInput,
     cmReleaseInput,
+    cmCopySelection,
     hcInputGrabbed,
 };
 


### PR DESCRIPTION
Implement mouse-driven text selection with highlighted rendering and clipboard copy. Left-button drag selects text when the terminal app has not captured the mouse; wheel/middle/right are always forwarded.

Selection highlight uses reverseAttribute() on surface cells written via writeLine, ensuring deterministic rendering compatible with the existing damage-reuse optimisation.

Copy to system clipboard via platform-native tools (pbcopy/xclip/xsel) on Unix. Accessible through the menu (Copy Selection).

Partially addresses https://github.com/magiblot/tvterm/issues/5.